### PR TITLE
Remove kotlin boms

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -23,9 +23,6 @@ test {
 }
 
 dependencies {
-    // Align versions of all Kotlin components
-    implementation platform('org.jetbrains.kotlin:kotlin-bom')
-
     implementation project(":core")
     implementation project(":tornadofx")
     implementation 'no.tornado:tornadofx:1.7.19'

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -11,8 +11,6 @@ test {
 }
 
 dependencies {
-    // Align versions of all Kotlin components
-    implementation platform('org.jetbrains.kotlin:kotlin-bom')
     implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
 
     testImplementation 'org.junit.jupiter:junit-jupiter:5.5.2'

--- a/tornadofx/build.gradle
+++ b/tornadofx/build.gradle
@@ -11,7 +11,6 @@ test {
 }
 
 dependencies {
-    implementation platform('org.jetbrains.kotlin:kotlin-bom')
     implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
     implementation project(":core")
 


### PR DESCRIPTION
As of kotlin 1.2, gradle's kotlin plugin automatically provides
bom-like behaviour for standard kotlin dependencies. Specifically
importing a bom is no longer required.